### PR TITLE
5077: drill was_redirect through python to frontend

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1041,10 +1041,10 @@ ENABLE_SIGNUP = PersistentConfig(
 )
 
 # PATCH REDIRECT TO WAS
-WAS_REDIRECT = PersistentConfig(
-    "WAS_REDIRECT",
-    "ui.WAS_REDIRECT",
-    os.environ.get("WAS_REDIRECT", ""),
+WAS_REDIRECT_URL = PersistentConfig(
+    "WAS_REDIRECT_URL",
+    "ui.WAS_REDIRECT_URL",
+    os.environ.get("WAS_REDIRECT_URL", ""),
 )
 # /PATCH REDIRECT TO WAS
 

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1040,6 +1040,7 @@ ENABLE_SIGNUP = PersistentConfig(
     ),
 )
 
+
 # PATCH REDIRECT TO WAS
 WAS_REDIRECT_URL = PersistentConfig(
     "WAS_REDIRECT_URL",
@@ -1047,6 +1048,7 @@ WAS_REDIRECT_URL = PersistentConfig(
     os.environ.get("WAS_REDIRECT_URL", ""),
 )
 # /PATCH REDIRECT TO WAS
+
 
 ENABLE_LOGIN_FORM = PersistentConfig(
     "ENABLE_LOGIN_FORM",

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1040,6 +1040,14 @@ ENABLE_SIGNUP = PersistentConfig(
     ),
 )
 
+# PATCH REDIRECT TO WAS
+WAS_REDIRECT = PersistentConfig(
+    "WAS_REDIRECT",
+    "ui.WAS_REDIRECT",
+    os.environ.get("WAS_REDIRECT", ""),
+)
+# /PATCH REDIRECT TO WAS
+
 ENABLE_LOGIN_FORM = PersistentConfig(
     "ENABLE_LOGIN_FORM",
     "ui.ENABLE_LOGIN_FORM",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -334,6 +334,9 @@ from open_webui.config import (
     PENDING_USER_OVERLAY_TITLE,
     DEFAULT_PROMPT_SUGGESTIONS,
     DEFAULT_MODELS,
+    # PATCH REDIRECT TO WAS
+    WAS_REDIRECT,
+    # /PATCH REDIRECT TO WAS
     DEFAULT_ARENA_MODEL,
     MODEL_ORDER_LIST,
     EVALUATION_ARENA_MODELS,
@@ -700,6 +703,10 @@ app.state.config.ADMIN_EMAIL = ADMIN_EMAIL
 app.state.config.DEFAULT_MODELS = DEFAULT_MODELS
 app.state.config.DEFAULT_PROMPT_SUGGESTIONS = DEFAULT_PROMPT_SUGGESTIONS
 app.state.config.DEFAULT_USER_ROLE = DEFAULT_USER_ROLE
+
+# PATCH REDIRECT TO WAS
+app.state.config.WAS_REDIRECT = WAS_REDIRECT
+# /PATCH REDIRECT TO WAS
 
 app.state.config.PENDING_USER_OVERLAY_CONTENT = PENDING_USER_OVERLAY_CONTENT
 app.state.config.PENDING_USER_OVERLAY_TITLE = PENDING_USER_OVERLAY_TITLE
@@ -1643,6 +1650,12 @@ async def get_app_config(request: Request):
                 name: config.get("name", name)
                 for name, config in OAUTH_PROVIDERS.items()
             }
+        },
+        # Environment variables for patches
+        "extended_features": {
+            # PATCH REDIRECT TO WAS
+            "was_redirect": app.state.config.WAS_REDIRECT,
+            # /PATCH REDIRECT TO WAS
         },
         "features": {
             "auth": WEBUI_AUTH,

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -335,7 +335,7 @@ from open_webui.config import (
     DEFAULT_PROMPT_SUGGESTIONS,
     DEFAULT_MODELS,
     # PATCH REDIRECT TO WAS
-    WAS_REDIRECT,
+    WAS_REDIRECT_URL,
     # /PATCH REDIRECT TO WAS
     DEFAULT_ARENA_MODEL,
     MODEL_ORDER_LIST,
@@ -705,7 +705,7 @@ app.state.config.DEFAULT_PROMPT_SUGGESTIONS = DEFAULT_PROMPT_SUGGESTIONS
 app.state.config.DEFAULT_USER_ROLE = DEFAULT_USER_ROLE
 
 # PATCH REDIRECT TO WAS
-app.state.config.WAS_REDIRECT = WAS_REDIRECT
+app.state.config.WAS_REDIRECT_URL = WAS_REDIRECT_URL
 # /PATCH REDIRECT TO WAS
 
 app.state.config.PENDING_USER_OVERLAY_CONTENT = PENDING_USER_OVERLAY_CONTENT
@@ -1654,7 +1654,7 @@ async def get_app_config(request: Request):
         # Environment variables for patches
         "extended_features": {
             # PATCH REDIRECT TO WAS
-            "was_redirect": app.state.config.WAS_REDIRECT,
+            "was_redirect_url": app.state.config.WAS_REDIRECT_URL,
             # /PATCH REDIRECT TO WAS
         },
         "features": {

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -261,6 +261,12 @@ type Config = {
 		enable_direct_connections: boolean;
 		enable_version_update_check: boolean;
 	};
+	// Environment variables for patches
+	extended_features: {
+		// PATCH REDIRECT TO WAS
+		was_redirect: string;
+		// /PATCH REDIRECT TO WAS
+	};
 	oauth: {
 		providers: {
 			[key: string]: string;

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -264,7 +264,7 @@ type Config = {
 	// Environment variables for patches
 	extended_features: {
 		// PATCH REDIRECT TO WAS
-		was_redirect: string;
+		was_redirect_url: string;
 		// /PATCH REDIRECT TO WAS
 	};
 	oauth: {

--- a/src/routes/was/+page.svelte
+++ b/src/routes/was/+page.svelte
@@ -2,10 +2,12 @@
 <script>
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-    
+	import { config } from '$lib/stores';
+
 	onMount(async () => {
-		const WAS_REDIRECT = import.meta.env.PUBLIC_WAS_REDIRECT || false;
-		WAS_REDIRECT ? window.open(WAS_REDIRECT, '_blank') : goto("/"); 
+		const WAS_REDIRECT = $config?.extended_features?.was_redirect || false;
+		if (WAS_REDIRECT) window.open(JSON.parse(WAS_REDIRECT), '_blank');
+		goto('/');
 	});
 </script>
 <!-- /PATCH REDIRECT TO WAS -->

--- a/src/routes/was/+page.svelte
+++ b/src/routes/was/+page.svelte
@@ -5,8 +5,8 @@
 	import { config } from '$lib/stores';
 
 	onMount(async () => {
-		const WAS_REDIRECT = $config?.extended_features?.was_redirect || false;
-		if (WAS_REDIRECT) window.open(JSON.parse(WAS_REDIRECT), '_blank');
+		const WAS_REDIRECT_URL = $config?.extended_features?.was_redirect_url || false;
+		if (WAS_REDIRECT_URL) window.open(JSON.parse(WAS_REDIRECT_URL), '_blank');
 		goto('/');
 	});
 </script>


### PR DESCRIPTION
https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=5077#/tickets/showTicket/5077


- Drill was_redirect through python by config
- Add extended_features for patch environment variables

friends with: https://github.com/ai-platform-infrastructure/open-webui-docker/pull/15