### PR TITLE
5234: add two helper functions, as config seem to be loaded in a diff…

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -442,6 +442,25 @@
 
 		await tick();
 	};
+
+	// PATCH ADD LOGO TO SIDEBAR
+	function IsJson(str) {
+		try {
+			JSON.parse(str);
+		} catch (e) {
+			return false;
+		}
+		return true;
+	}
+
+	function getUrl(str) {
+		if (IsJson(str)) {
+			return JSON.parse(str);
+		} else {
+			return str;
+		}
+	}
+	// /PATCH ADD LOGO TO SIDEBAR
 </script>
 
 <ArchivedChatsModal
@@ -1111,8 +1130,10 @@
 				</Folder>
 			</div>
 
- 			<!-- PATCH ADD LOGO TO SIDEBAR: pb-[50px]-class added -->
-			 <div class="px-1.5 pt-1.5 pb-2 sticky bottom-0 z-10 bg-gray-50 dark:bg-gray-950 sidebar pb-[50px]">
+			<!-- PATCH ADD LOGO TO SIDEBAR: pb-[50px]-class added -->
+			<div
+				class="px-1.5 pt-1.5 pb-2 sticky bottom-0 z-10 bg-gray-50 dark:bg-gray-950 sidebar pb-[50px]"
+			>
 				<!-- /PATCH ADD LOGO TO SIDEBAR -->
 				<div class="flex flex-col font-primary">
 					{#if $user !== undefined && $user !== null}
@@ -1143,10 +1164,18 @@
 			</div>
 		</div>
 		<!-- PATCH ADD LOGO TO SIDEBAR -->
-		 <div class="relative">
-			<div class="-mb-2 flex items-center py-2.5 px-4.5 w-full bg-gray-800 absolute left-0 bottom-0 z-20">
+		<div class="relative">
+			<div
+				class="-mb-2 flex items-center py-2.5 px-4.5 w-full bg-gray-800 absolute left-0 bottom-0 z-20"
+			>
 				<div class="self-center mr-3">
-					<img src={$config?.extended_features?.logo_url ? JSON.parse($config?.extended_features?.logo_url) : ""} class="max-w-[150px] object-cover" alt="" />
+					<img
+						src={$config?.extended_features?.logo_url
+							? getUrl($config?.extended_features?.logo_url)
+							: ''}
+						class="max-w-[150px] object-cover"
+						alt=""
+					/>
 				</div>
 			</div>
 		</div>

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -165,6 +165,25 @@
 			onboarding = $config?.onboarding ?? false;
 		}
 	});
+
+	// PATCH EXTRA LOGIN INFO
+	function IsJson(str) {
+		try {
+			JSON.parse(str);
+		} catch (e) {
+			return false;
+		}
+		return true;
+	}
+
+	function getUrl(str) {
+		if (IsJson(str)) {
+			return JSON.parse(str);
+		} else {
+			return str;
+		}
+	}
+	// /PATCH EXTRA LOGIN INFO
 </script>
 
 <svelte:head>
@@ -395,7 +414,7 @@
 										id: '1',
 										dismissible: false,
 										title: 'Vigtigt før du logger ind første gang!',
-										content: `<div>Du skal have adgang til AI-Platform i Aarhus Kommunes Systemregister.</div><div><a target="_blank" rel="noopener noreferrer" class='underline' href='${JSON.parse($config?.extended_features?.system_register_url)}'>Anmod om adgang i systemregistret</a></div>.</div><div>Du kan <a target="_blank" rel="noopener noreferrer" class='underline' href='${JSON.parse($config?.extended_features?.system_register_guide_url)}'>hente en vejledning til hvordan man anmoder om adgang til systemregistret</a></div>`
+										content: `<div>Du skal have adgang til AI-Platform i Aarhus Kommunes Systemregister.</div><div><a target="_blank" rel="noopener noreferrer" class='underline' href='${getUrl($config?.extended_features?.system_register_url)}'>Anmod om adgang i systemregistret</a></div>.</div><div>Du kan <a target="_blank" rel="noopener noreferrer" class='underline' href='${getUrl($config?.extended_features?.system_register_guide_url)}'>hente en vejledning til hvordan man anmoder om adgang til systemregistret</a></div>`
 									}}
 								></Banner>
 							{/if}

--- a/src/routes/was/+page.svelte
+++ b/src/routes/was/+page.svelte
@@ -4,10 +4,28 @@
 	import { goto } from '$app/navigation';
 	import { config } from '$lib/stores';
 
+	function IsJson(str) {
+		try {
+			JSON.parse(str);
+		} catch (e) {
+			return false;
+		}
+		return true;
+	}
+
+	function getUrl(str) {
+		if (IsJson(str)) {
+			return JSON.parse(str);
+		} else {
+			return str;
+		}
+	}
+
 	onMount(async () => {
 		const WAS_REDIRECT_URL = $config?.extended_features?.was_redirect_url || false;
-		if (WAS_REDIRECT_URL) window.open(JSON.parse(WAS_REDIRECT_URL), '_blank');
+		if (WAS_REDIRECT_URL) window.open(getUrl(WAS_REDIRECT_URL), '_blank');
 		goto('/');
 	});
 </script>
+
 <!-- /PATCH REDIRECT TO WAS -->


### PR DESCRIPTION
# Task 

https://leantime.itkdev.dk/dashboard/show#/tickets/showTicket/5234

# Description

So, this is a perhaps fix for a problem that I cannot seem to recreate locally. This problem *should* be handled by inconsistencies in the way environment variables are handled, but I cannot find any inconsistencies... But perhaps this works? 

This is how the config is loaded in production, some with "\", some not.

This works locally, but it also works locally without this.

Why copy pasting methods? It's the Open WebUI way.

<img width="804" height="217" alt="Screenshot 2025-08-22 at 10 57 31" src="https://github.com/user-attachments/assets/6823e517-a30e-468c-88e6-7c091b9dc849" />
