### PR TITLE
5271: remove use of openwebui banner and change text

### DIFF
--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -403,7 +403,6 @@
 											<div class="mb-2">
 												<a
 													target="_blank"
-													rel="noopener noreferrer"
 													class="underline"
 													href="${$config?.extended_features?.system_register_url}"
 													>Anmod om adgang i Systemregisteret.</a
@@ -412,7 +411,6 @@
 											<div class="mb-2">
 												<a
 													target="_blank"
-													rel="noopener noreferrer"
 													class="underline"
 													href="${$config?.extended_features?.system_register_guide_url}"
 													>Vejledning til at anmode om adgang i Systemregisteret på Serviceportalen.</a


### PR DESCRIPTION
# Task

https://leantime.itkdev.dk/?tab=timesheet#/tickets/showTicket/5271

Change text and remove use of `<Banner` as it strips `target="_blank"`

# Image

<img width="576" height="458" alt="image" src="https://github.com/user-attachments/assets/92c6a426-89fa-4c65-a569-08f824869525" />
