### PR TITLE
"Pinned" banner to chat

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2839,6 +2839,16 @@
 								</div>
 							</div>
 
+							<!-- PATCH ADD BANNERS TO CHAT INPUT -->
+							{#if !showCommands}
+								{#each $banners as banner}
+									{#if !banner.dismissible}
+										<Banner {banner} className="mx-4 my-2" />
+									{/if}
+								{/each}
+							{/if}
+							<!-- /PATCH ADD BANNERS TO CHAT INPUT -->
+
 							<div class=" pb-2 {dragged ? 'z-0' : 'z-10'}">
 								<MessageInput
 									bind:this={messageInput}


### PR DESCRIPTION
# Patch icons instead of images

## Leantime stuff

[Leantime ticket 4472
](https://leantime.itkdev.dk/#/tickets/showTicket/4472)

## Patch stuff

- This "pins" the banner, only the banner where dismiss is not saved in `localstorage`, to the current chat.

## But how does it look...

... It looks like this: 

<img width="1064" height="810" alt="image" src="https://github.com/user-attachments/assets/a597bf1e-e7e9-4cdb-afd0-91c54ab60c55" />

.. And this: 

<img width="1067" height="965" alt="image" src="https://github.com/user-attachments/assets/51dc1af7-e1d8-4baa-a9db-7b3d1f250a80" />
